### PR TITLE
Fix: Resolving Type Cast Error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M

--- a/flutter_appavailability_android.iml
+++ b/flutter_appavailability_android.iml
@@ -23,7 +23,7 @@
     <content url="file://$MODULE_DIR$/example/android">
       <sourceFolder url="file://$MODULE_DIR$/example/android/app/src/main/java" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 27 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Flutter for Android" level="project" />
   </component>

--- a/lib/flutter_appavailability.dart
+++ b/lib/flutter_appavailability.dart
@@ -26,8 +26,8 @@ class AppAvailability {
     args.putIfAbsent('uri', () => uri);
 
     if (Platform.isAndroid) {
-      Map<dynamic, dynamic> app = await (_channel.invokeMethod(
-          "checkAvailability", args) as FutureOr<Map<dynamic, dynamic>>);
+      final result = await _channel.invokeMethod("checkAvailability", args);
+      Map<dynamic, dynamic> app = result as Map<dynamic, dynamic>;
       return {
         "app_name": app["app_name"],
         "package_name": app["package_name"],


### PR DESCRIPTION
# Issues Handed
- Building a flutter android apk failed due to the android project being androidX compatible.
- In case of result.error from AppAvailability.java the result received on dart is not of type Map<dynamic, dynamic> instead it's a Platform Exception.

# Resolution
I tested the code on Android API 29. However, there was a build failure due to AndroidX compatibility. Hence, I have migrated android code to support AndroidX.
Also there was a type cast error being encountered instead of PlatformException when an application is unavailable for android devices. 

# Checklist
- [x] Tested in Android
- [x] Tested in IOS